### PR TITLE
Avoid failing when LZFSE stores the uncompressed data.

### DIFF
--- a/pylzfse.c
+++ b/pylzfse.c
@@ -85,7 +85,9 @@ lzfse_op(PyObject* self,
 static size_t
 get_encode_outlen(const size_t inlen)
 {
-    return inlen;
+    /* Extra 12 bytes for start/end block magics and block length in case the compressed output is
+       larger than the input, as in lzfse_encode.c */
+    return inlen + 12;
 }
 
 static PyObject*


### PR DESCRIPTION
When compression fails (for example, when the data is small or non
compressible), LZFSE falls back to storing the data uncompressed with
start/end of block magics and the length of the block, which adds an
additional 12 bytes to the output.